### PR TITLE
Added a Zen mode

### DIFF
--- a/browser/index.html
+++ b/browser/index.html
@@ -50,6 +50,7 @@
 
         <script src="../node_modules/katex/dist/katex.min.js"></script>
 
+        <script type="text/javascript" src='moe-zen.js'></script>
         <script type="text/javascript" src="moe-document.js"></script>
         <script type="text/javascript" src="moe-localize.js"></script>
     </head>
@@ -89,6 +90,7 @@
                     <div class="button-bottom" id="button-bottom-new" data-action="new">NEW</div>
                     <div class="button-bottom" id="button-bottom-open" data-action="open">OPEN</div>
                     <div class="button-bottom" id="button-bottom-save" data-action="save">SAVE</div>
+                    <a   class="button-bottom" id="button-bottom-zen"><div>ZEN</div></a>
                 </div>
             </div>
         </div>

--- a/browser/moe-style.css
+++ b/browser/moe-style.css
@@ -32,6 +32,12 @@ html, body {
     background-color: rgb(245, 245, 245);
 }
 
+
+.left-panel-zen-mode {
+  width: 100% !important;
+}
+
+
 #right-panel {
     float: right;
     width: 50%;

--- a/browser/moe-zen.js
+++ b/browser/moe-zen.js
@@ -1,0 +1,25 @@
+/*
+ *  This file is part of Moeditor.
+ *
+ *  Copyright (c) 2016 Menci <huanghaorui301@gmail.com>
+ *
+ *  Moeditor is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  Moeditor is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with Moeditor. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+$(function(){
+  $('#button-bottom-zen').click(function(){
+      $("#right-panel").toggle();
+      $('#left-panel').toggleClass('left-panel-zen-mode')
+  })
+});


### PR DESCRIPTION
Added a Zen Mode toggle, as requested [Issue 34](https://github.com/Moeditor/Moeditor/issues/34)

>The editor looks amazing. It would be great if I could have the raw-markdown part in the middle of the screen, with nothing beside it. No preview

I made the following changes
- Added CSS for toggling between Zen mode and not Zen
- Added a *zen* button at the bottom 
- Added ```moe-zen.js``` which handles the toggle code 

