### PR TITLE
Changed zen-mode width to match Ghostwriter.

### DIFF
--- a/browser/moe-style.css
+++ b/browser/moe-style.css
@@ -131,19 +131,21 @@ html, body {
 }
 
 #editor.zen-mode.zen-mode-thin {
-    width: 60%;
-    margin-left: 20%;
-    margin-right: 20%;
+    width: calc(100% / 3);
+    margin-left: calc(100% / 3);
+    margin-right: calc(100% / 3);
 }
 
 #editor.zen-mode.zen-mode-medium {
-    width: 80%;
-    margin-left: 10%;
-    margin-right: 10%;
+    width: calc(100% / 2);
+    margin-left: calc(100% / 4);
+    margin-right: calc(100% / 4);
 }
 
 #editor.zen-mode.zen-mode-wide {
-    width: 100%;
+    width: calc((100% / 3) * 2);
+    margin-left: calc(100% / 6);
+    margin-right: calc(100% / 6);
 }
 
 #editor.zen-mode.zen-mode-thin .CodeMirror-scroll, #editor.zen-mode.zen-mode-medium .CodeMirror-scroll {


### PR DESCRIPTION
This means 33% width for narrow mode; 50% medium mode; 67% wide mode.

This is relevant to #36 . Ghostwriter config taken from https://github.com/wereturtle/ghostwriter/blob/a1fc5914ba9cdc5f651f02240cac18b134f2e0be/src/MarkdownEditor.cpp#L266