### PR TITLE
speed up sidemenu transition

### DIFF
--- a/views/main/moe-sidemenu.js
+++ b/views/main/moe-sidemenu.js
@@ -34,7 +34,7 @@ document.addEventListener('DOMContentLoaded', () => {
         sideMenuCover.style.pointerEvents = 'all';
         setTimeout(() => {
             document.getElementById('main').classList.add('notransition');
-        }, 500);
+        }, 200);
     }
 
     function hideMenu() {
@@ -44,7 +44,7 @@ document.addEventListener('DOMContentLoaded', () => {
         sideMenuCover.style.pointerEvents = 'none';
         setTimeout(() => {
             document.getElementById('main').classList.add('notransition');
-        }, 500);
+        }, 200);
     }
 
     sideMenuCover.addEventListener('click', hideMenu);

--- a/views/main/moe-style.css
+++ b/views/main/moe-style.css
@@ -32,7 +32,7 @@ html, body {
     margin-left: -300px;
     height: 100%;
     background: #fafafa;
-    transition: all 500ms ease-in-out;
+    transition: all 200ms ease-in-out;
     padding-top: 45px;
     padding-bottom: 45px;
     cursor: default;


### PR DESCRIPTION
First of all, really nice project, good job!

This may be a totally personal issue, but I find the the speed the sidemenu opens far too slow, it feels like I have to wait for the menu to open before I can do anything else, so hereby a PR that speeds it up to 200ms

This feels fluid to me, but you may think otherwise.