### PR TITLE
Improved codestyle

### DIFF
--- a/views/main/base16-light.css
+++ b/views/main/base16-light.css
@@ -71,3 +71,10 @@
 
 /*.cm-s-base16-light .CodeMirror-activeline-background {background: #DDDCDC !important;}*/
 .cm-s-base16-light .CodeMirror-matchingbracket { text-decoration: underline; color: white !important;}
+
+.cm-s-base16-light span.cm-em {color: #28d573;}
+.cm-s-base16-light span.cm-strong {color: #1a88d7;}
+.cm-s-base16-light span.cm-string.cm-url {color: #d57d34;}
+
+.cm-s-base16-light span.cm-header {line-height: 1; display: block;}
+.cm-s-base16-light span.cm-hr {line-height: 1; display: block; font-weight: bold; text-align: center; }

--- a/views/main/base16-light.css
+++ b/views/main/base16-light.css
@@ -75,6 +75,3 @@
 .cm-s-base16-light span.cm-em {color: #28d573;}
 .cm-s-base16-light span.cm-strong {color: #1a88d7;}
 .cm-s-base16-light span.cm-string.cm-url {color: #d57d34;}
-
-.cm-s-base16-light span.cm-header {line-height: 1; display: block;}
-.cm-s-base16-light span.cm-hr {line-height: 1; display: block; font-weight: bold; text-align: center; }


### PR DESCRIPTION
I added basic colors to `em`'s, `strong`'s and improved the color of the url definitions because it was hardly readable.

Looks like this:
![image](https://cloud.githubusercontent.com/assets/6538827/22339994/2f9143ca-e3ec-11e6-92f9-a47aa48fa721.png)
