### PR TITLE
Preserve line separators of each files

### DIFF
--- a/app/moe-file.js
+++ b/app/moe-file.js
@@ -23,6 +23,22 @@
 const fs = require('fs'),
       mime = require('mime');
 
+const lineSeparators=['\r\n','\r'];
+let fileLineSeparators={};
+
+function normalizeLineEndings(str) {
+    if (!str) return str;
+    return str.replace(/\r\n|\r/g, '\n');
+}
+function restoreLineEndings(fileName,str) {
+    if (!str) return str;
+    
+    let sep=fileLineSeparators[fileName]
+    if(sep===undefined){return str;}
+
+    return str.replace(/\n/g,sep);
+}
+
 class MoeditorFile {
     static isFile(fileName) {
         try {
@@ -52,17 +68,30 @@ class MoeditorFile {
 
     static read(fileName, empty) {
         try {
-            return fs.readFileSync(fileName);
+            var content=fs.readFileSync(fileName,"utf8");
+
+            for(let i in lineSeparators){
+                let sep=lineSeparators[i];
+                if(content.indexOf(sep)>=0){
+                    fileLineSeparators[fileName]=sep;break;
+                }
+            }
+
+            return normalizeLineEndings(content);
         } catch(e) {
             return empty;
         }
     }
 
     static write(fileName, content) {
+        content=restoreLineEndings(fileName,content)
+        
         return fs.writeFileSync(fileName, content);
     }
 
     static writeAsync(fileName, content, cb) {
+        content=restoreLineEndings(fileName,content)
+
         return fs.writeFile(fileName, content, cb);
     }
 


### PR DESCRIPTION
Normalizing all the line separators to UNIX style ‘\n’ after reading from files,and restoring to original separators ('\r' or '\r\n') before saving.