### PR TITLE
 Remove Telegram Link & deprecated domain name

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,6 @@ Your all-purpose markdown editor.
 
 Built with Electron.
 
-**Discuss on Telegram: https://t.me/Moeditor and help me work on the new version!**
-
 Visit our [homepage](https://moeditor.github.io/) or download [releases](https://github.com/Moeditor/Moeditor/releases).
 
 # Features

--- a/README.md
+++ b/README.md
@@ -73,8 +73,5 @@ Some node modules are licensed under other free software license.
 
 The `Raleway` font is licensed under the OFL open font license.
 
-# Credits
-The domain `moeditor.org` is sponsored by [Showfom](https://ttt.tt/).
-
 # Known Bug(s)
 Issue #31.


### PR DESCRIPTION
Since Menci no longer uses Telegram and the domain name has expired, remove them.