### PR TITLE
Add a snap

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
   "main": "app/index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "start": "electron ."
+    "start": "electron .",
+    "dist": "build -l snap",
+    "postinstall": "electron-builder install-app-deps"
   },
   "repository": {
     "type": "git",
@@ -25,7 +27,6 @@
     "biu.js": "^1.2.0",
     "codemirror": "^5.18.2",
     "configstore": "^2.1.0",
-    "electron": "^1.4.0",
     "electron-localshortcut": "^0.6.1",
     "electron-titlebar": "0.0.2",
     "flowchart.js": "^1.6.3",
@@ -42,5 +43,14 @@
     "moemark": "^0.3.8",
     "os-locale": "^1.4.0",
     "raphael": "^2.2.1"
+  },
+  "devDependencies": {
+    "electron": "^1.4.0",
+    "electron-builder": "^20.31.2"
+  },
+  "build": {
+    "linux": {
+      "icon": "icons/Moeditor.icns"
+    }
   }
 }


### PR DESCRIPTION
Hi,

I created a snap package of Moeditor so it can be featured to the millions of Linux users installing apps from the [Snap Store](https://snapcraft.io/store). If you're willing to publish this under the Moeditor project name, you just need to [create an account](https://snapcraft.io/snaps) and then [register the moeditor name](https://snapcraft.io/register-snap).

The snap file created by `npm run dist` can then be released in the Snap Store with `snap push --release stable *.snap`. You'll want to install snapcraft (`brew install snapcraft`, `snap install snapcraft`, or `apt install snapcraft`) and login (`snapcraft login`) first, though.

Thanks for making Moeditor 😃 